### PR TITLE
fixes

### DIFF
--- a/api/authn/user_store.go
+++ b/api/authn/user_store.go
@@ -39,11 +39,13 @@ func (s *userStore) Create(apiContext *types.APIContext, schema *types.Schema, d
 		return nil, err
 	}
 
-	if pids, ok := created[client.UserFieldPrincipalIDs].([]interface{}); ok {
-		if id, ok := created[client.UserFieldId].(string); ok {
-			created[client.UserFieldPrincipalIDs] = append(pids, "local://"+id)
-			return s.Update(apiContext, schema, created, id)
+	if id, ok := created[client.UserFieldId].(string); ok {
+		var principalIDs []interface{}
+		if pids, ok := created[client.UserFieldPrincipalIDs].([]interface{}); ok {
+			principalIDs = pids
 		}
+		created[client.UserFieldPrincipalIDs] = append(principalIDs, "local://"+id)
+		return s.Update(apiContext, schema, created, id)
 	}
 
 	return created, err

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -111,5 +111,8 @@ func (c *Manager) toServer(ctx context.Context, cluster *client.Cluster) (*recor
 		return nil, err
 	}
 
+	if err := clusterContext.Start(ctx); err != nil {
+		return s, err
+	}
 	return s, nil
 }


### PR DESCRIPTION
-  start clusterContext for cluster ap
- set user's local principalID even if the principalIDs field was not originally preset